### PR TITLE
Definition lincense of MIT in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "gregwar/form-bundle",
     "description": "Provides the \"entity_id\" type (read \"entity identifier\")",
+    "license": "MIT",
     "require": {
         "symfony/symfony": ">=2.1,<2.4-dev",
         "symfony/framework-bundle": ">=2.1,<2.4-dev",


### PR DESCRIPTION
Gregwar/FormBundle defined under the MIT license.

However cannot be shown using composer (& [Packagist](https://packagist.org/packages/gregwar/form-bundle)).

Hope to define the same license in `composer.json`

> $ composer.phar show gregwar/form-bundle
> 
> name     : gregwar/form-bundle
> descrip. : Provides the "entity_id" type (read "entity identifier")
> keywords :
> versions : dev-master
> type     : library
> license  :
> source   : [git] https://github.com/Gregwar/FormBundle.git b71581831996d9c3dc43279a46bd1cd49dca703a
> dist     : [zip] https://api.github.com/repos/Gregwar/FormBundle/zipball/b71581831996d9c3dc43279a46bd1cd49dca703a b71581831996d9c3dc43279a46bd1cd49dca703a
> names    : gregwar/form-bundle
