### PR TITLE
Allow for Symfony 2.4

### DIFF
--- a/Tests/Functional/config.yml
+++ b/Tests/Functional/config.yml
@@ -7,6 +7,8 @@ framework:
     router:
         resource: "%kernel.root_dir%/config/routing.yml"
         strict_requirements: %kernel.debug%
+    session:
+        storage_id: session.storage.mock_file
 
 doctrine:
     dbal:

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
     "description": "Provides the \"entity_id\" type (read \"entity identifier\")",
     "license": "MIT",
     "require": {
-        "symfony/symfony": ">=2.1,<2.4-dev",
-        "symfony/framework-bundle": ">=2.1,<2.4-dev",
+        "symfony/symfony": ">=2.1,<2.5-dev",
+        "symfony/framework-bundle": ">=2.1,<2.5-dev",
         "doctrine/doctrine-bundle": "*",
         "doctrine/orm": "*"
     },
@@ -12,5 +12,5 @@
         "psr-0": { "Gregwar\\FormBundle": "" }
     },
     "target-dir": "Gregwar/FormBundle",
-    "minimum-stability": "dev"
+    "minimum-stability": "alpha"
 }


### PR DESCRIPTION
Since [Symfony 2.4.0 Beta 1](http://symfony.com/blog/symfony-2-4-0-beta-1-released) is out now, I'm bumping the dependencies. Tests works fine and I'll be updating our site to use this in production too.
