### PR TITLE
Set entity manager property as protected

### DIFF
--- a/DataTransformer/EntityToIdTransformer.php
+++ b/DataTransformer/EntityToIdTransformer.php
@@ -21,7 +21,7 @@ use Doctrine\ORM\NoResultException;
  */
 class EntityToIdTransformer implements DataTransformerInterface
 {
-    private $em;
+    protected $em;
     private $class;
     private $property;
     private $queryBuilder;


### PR DESCRIPTION
I'm extending `EntityToIdTransformer` and need access to the entity manager :)
