### PR TITLE
Change type hinting to allow others EntityManagerInterfaces

### DIFF
--- a/DataTransformer/EntityToIdTransformer.php
+++ b/DataTransformer/EntityToIdTransformer.php
@@ -2,6 +2,7 @@
 
 namespace Gregwar\FormBundle\DataTransformer;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\FormException;
 use Symfony\Component\Form\Exception\TransformationFailedException;
@@ -29,7 +30,7 @@ class EntityToIdTransformer implements DataTransformerInterface
 
     private $unitOfWork;
 
-    public function __construct(EntityManager $em, $class, $property, $queryBuilder, $multiple)
+    public function __construct(EntityManagerInterface $em, $class, $property, $queryBuilder, $multiple)
     {
         if (!(null === $queryBuilder || $queryBuilder instanceof QueryBuilder || $queryBuilder instanceof \Closure)) {
             throw new UnexpectedTypeException($queryBuilder, 'Doctrine\ORM\QueryBuilder or \Closure');


### PR DESCRIPTION
I'm using a decorated version of EntityManager in my project (see: EntityManagerDecorator) and the previous type hinting did not allow me to used this bundle.

Works well with this little change.